### PR TITLE
(Old branch) Feature: Pydantic V2 support

### DIFF
--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -20,6 +20,7 @@ jobs:
           - "3.10"
         lib-pydantic:
           - "1.10.0"
+          - "2.0.0a3"
         deps:
           - dev,docs
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,12 +20,7 @@ classifiers = [
     "Topic :: Software Development",
     "Typing :: Typed",
 ]
-dependencies = [
-    "pydantic>=1.10.0,<2",
-    "pydantic-yaml>=1.0.0a2",
-    "kedro",
-    "fsspec",
-]
+dependencies = ["pydantic>=1.10.0", "pydantic-yaml>=1.0.0a2", "kedro", "fsspec"]
 urls = { github = "https://github.com/NowanIlfideme/pydantic-kedro" }
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,12 @@ classifiers = [
     "Topic :: Software Development",
     "Typing :: Typed",
 ]
-dependencies = ["pydantic>=1.10.0", "pydantic-yaml>=1.0.0a2", "kedro", "fsspec"]
+dependencies = [
+    "pydantic>=1.10.0,<3",
+    "pydantic-yaml>=1.0.0a2",
+    "kedro",
+    "fsspec",
+]
 urls = { github = "https://github.com/NowanIlfideme/pydantic-kedro" }
 
 [project.optional-dependencies]
@@ -101,5 +106,12 @@ module = ["pydantic_kedro.*"]
 disallow_untyped_defs = true
 
 [[tool.mypy.overrides]]
-module = ["setuptools", "setuptools_scm", "fsspec.*", "cloudpickle", "fusepy"]
+module = [
+    "setuptools",
+    "setuptools_scm",
+    "fsspec.*",
+    "cloudpickle",
+    "fusepy",
+    "ruamel",
+]
 ignore_missing_imports = true

--- a/src/pydantic_kedro/_compat.py
+++ b/src/pydantic_kedro/_compat.py
@@ -1,0 +1,67 @@
+"""Pydantic compatibility module."""
+
+# type: ignore
+# flake8: noqa
+
+__all__ = ["get_field_names", "import_string"]
+
+import warnings
+from typing import Any, List, Type, no_type_check
+
+import pydantic
+
+if pydantic.VERSION >= "2":
+
+    @no_type_check
+    def get_field_names(kls: Type[pydantic.BaseModel]) -> List[str]:
+        """Return all field names of a Pydantic class."""
+        return list(kls.model_fields.keys())  # type: ignore
+
+    @no_type_check
+    def import_string(value: str) -> Any:
+        """Imports string."""
+        from pydantic._internal._validators import (
+            import_string as _imp_str,  # type: ignore
+        )
+
+        return _imp_str(value)
+
+    @no_type_check
+    def get_config_attr(kls: Type[pydantic.BaseModel], attr: str, default: Any = None) -> Any:
+        """Gets attribute from the config class."""
+        # FIXME: Maybe we change how the config is done?
+        return kls.model_config.get("kedro_default", default)  # type: ignore
+
+    @no_type_check
+    def apply_model_json_encoder(kls: Type[pydantic.BaseModel], obj: Any) -> Any:
+        """Applies the model's JSON encoder."""
+        # TODO: Update once pydantic>2 adds ability to use custom encoders.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            from pydantic.deprecated.json import pydantic_encoder
+
+            return pydantic_encoder(obj)  # type: ignore
+
+elif pydantic.VERSION >= "1":
+
+    @no_type_check
+    def get_field_names(kls: Type[pydantic.BaseModel]) -> List[str]:
+        """Return all field names of a Pydantic class."""
+        return list(kls.__fields__.keys())  # type: ignore
+
+    @no_type_check
+    def import_string(value: str) -> Any:
+        """Imports string."""
+        from pydantic.utils import import_string as _imp_str  # type: ignore
+
+        return _imp_str(value)
+
+    @no_type_check
+    def get_config_attr(kls: Type[pydantic.BaseModel], attr: str, default: Any = None) -> Any:
+        """Gets attribute from the config class."""
+        return getattr(kls.__config__, "kedro_default", default)  # type: ignore
+
+    @no_type_check
+    def apply_model_json_encoder(kls: Type[pydantic.BaseModel], obj: Any) -> Any:
+        """Applies the model's JSON encoder."""
+        return kls.__json_encoder__(obj)  # type: ignore

--- a/src/pydantic_kedro/datasets/folder.py
+++ b/src/pydantic_kedro/datasets/folder.py
@@ -281,7 +281,8 @@ class PydanticFolderDataSet(AbstractDataSet[BaseModel, BaseModel]):
                 return val
 
         # Roundtrip to apply the encoder and get UUID
-        rt = json.loads(data.json(encoder=fake_encoder))
+        raise NotImplementedError("Custom encoders are currently unavailable in Pydantic V2.")
+        rt = json.loads(data.json(encoder=fake_encoder))  # FIXME: Unavailable in Pydantic V2
 
         # This will map the data to a dataset and actually save it
 

--- a/src/pydantic_kedro/datasets/json.py
+++ b/src/pydantic_kedro/datasets/json.py
@@ -8,7 +8,8 @@ import fsspec
 from fsspec import AbstractFileSystem
 from kedro.io.core import AbstractDataSet, get_filepath_str, get_protocol_and_path
 from pydantic import BaseModel, create_model, parse_obj_as
-from pydantic.utils import import_string
+
+from pydantic_kedro._compat import get_field_names, import_string
 
 KLS_MARK_STR = "class"
 
@@ -71,7 +72,7 @@ class PydanticJsonDataSet(AbstractDataSet[BaseModel, BaseModel]):
         """Save Pydantic model to the filepath."""
         # Add metadata to our Pydantic model
         pyd_kls = type(data)
-        if KLS_MARK_STR in pyd_kls.__fields__.keys():
+        if KLS_MARK_STR in get_field_names(pyd_kls):
             raise ValueError(f"Marker {KLS_MARK_STR!r} already exists as a field; can't dump model.")
         pyd_kls_path = f"{pyd_kls.__module__}.{pyd_kls.__qualname__}"
         tmp_kls = create_model(

--- a/src/pydantic_kedro/datasets/yaml.py
+++ b/src/pydantic_kedro/datasets/yaml.py
@@ -7,8 +7,9 @@ import fsspec
 from fsspec import AbstractFileSystem
 from kedro.io.core import AbstractDataSet, get_filepath_str, get_protocol_and_path
 from pydantic import BaseModel, Field, create_model
-from pydantic.utils import import_string
 from pydantic_yaml import parse_yaml_file_as, to_yaml_file
+
+from pydantic_kedro._compat import get_field_names, import_string
 
 KLS_MARK_STR = "class"
 
@@ -74,7 +75,7 @@ class PydanticYamlDataSet(AbstractDataSet[BaseModel, BaseModel]):
         """Save Pydantic model to the filepath."""
         # Add metadata to our Pydantic model
         pyd_kls = type(data)
-        if KLS_MARK_STR in pyd_kls.__fields__.keys():
+        if KLS_MARK_STR in get_field_names(pyd_kls):
             raise ValueError(f"Marker {KLS_MARK_STR!r} already exists as a field; can't dump model.")
         pyd_kls_path = f"{pyd_kls.__module__}.{pyd_kls.__qualname__}"
         tmp_kls = create_model(


### PR DESCRIPTION
Trying to add support for Pydantic V2.

Currently, it's impossible, as Pydantic doesn't support cusom encoders for JSON (or any other type). Or at least I couldn't figure out how to add it; it's referenced in docs.

Related issues/discussions in Pydantic:

Main discussion - https://github.com/pydantic/pydantic/discussions/4456

Apparently, serialization is already implemented here? - https://github.com/pydantic/pydantic/issues/4739 - but I can't find any documentation, and I can't find it in the Python interface code for pydantic-core.

V1 JSON Encoder issue/discussion - https://github.com/pydantic/pydantic/issues/2277

Closes #15 when merged.
