### PR TITLE
Keep type information for nested Pydantic models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,5 +106,12 @@ module = ["pydantic_kedro.*"]
 disallow_untyped_defs = true
 
 [[tool.mypy.overrides]]
-module = ["setuptools", "setuptools_scm", "fsspec.*", "cloudpickle", "fusepy"]
+module = [
+    "setuptools",
+    "setuptools_scm",
+    "fsspec.*",
+    "cloudpickle",
+    "fusepy",
+    "ruamel.yaml",
+]
 ignore_missing_imports = true

--- a/src/pydantic_kedro/_dict_io.py
+++ b/src/pydantic_kedro/_dict_io.py
@@ -1,0 +1,139 @@
+"""Module for reading/writing from dicts."""
+
+from contextlib import AbstractContextManager
+from types import TracebackType
+from typing import Any, Dict, List, Optional, Type
+
+from pydantic import BaseModel, parse_obj_as
+from pydantic.utils import import_string
+
+KLS_MARK_STR = "class"
+
+
+def get_kls_path(pyd_kls: Type[BaseModel]) -> str:
+    """Get the class path for an object."""
+    return f"{pyd_kls.__module__}.{pyd_kls.__qualname__}"
+
+
+class PatchPydanticIter(AbstractContextManager):
+    """Patch Pydantic `_iter` method.
+
+    The _iter method is used by `.json()` and `.dict()` for exporting.
+    We add our class information.
+
+    Simple Example
+    --------------
+
+    ```python
+    class A(BaseModel):
+        x: str = "x"
+
+    print(A().json())
+    with PatchPydanticIter():
+        print(A().json())
+    print(A().json())
+    ```
+
+    Output:
+
+    ```txt
+    {"x": "x"}
+    {"class": "A", "x": "x"}
+    {"x": "x"}
+    ```
+
+    Nested Example
+    --------------
+
+    ```python
+    class C(BaseModel):
+        a: A = A()
+
+    print(C().json())
+    with PatchPydanticIter():
+        print(C().json())
+    print(C().json())
+    ```
+
+    Output:
+
+    ```txt
+    {"a": {"x": "x"}}
+    {"class": "C", "a": {"class": "A", "x": "x"}}
+    {"a": {"x": "x"}}
+    ```
+
+    """
+
+    def __init__(self) -> None:
+        self.orig_iter = BaseModel._iter
+        self.add_kls_mark = True
+
+    def __enter__(self) -> None:
+        orig_iter = self.orig_iter
+        add_kls_mark = self.add_kls_mark
+
+        def _iter(self, to_dict=False, **kwargs):  # type: ignore
+            nonlocal orig_iter, add_kls_mark
+            if add_kls_mark:  # add 'class' as first item
+                kls_path = get_kls_path(type(self))
+                yield KLS_MARK_STR, kls_path
+
+            for k, v in orig_iter(self, to_dict=to_dict, **kwargs):
+                yield k, v
+
+        BaseModel._iter = _iter  # type: ignore
+
+    def __exit__(
+        self,
+        __exc_type: Optional[Type[BaseException]] = None,
+        __exc_value: Optional[BaseException] = None,
+        __traceback: Optional[TracebackType] = None,
+    ) -> Optional[bool]:
+        BaseModel._iter = self.orig_iter
+        return super().__exit__(__exc_type, __exc_value, __traceback)
+
+
+def _classlike(obj: Any) -> bool:
+    if isinstance(obj, dict):
+        if KLS_MARK_STR in obj.keys():
+            return True
+    return False
+
+
+def _list_manip(value: List[Any]) -> List[Any]:
+    new_value = list(value)
+    for i, v_i in enumerate(value):
+        if isinstance(v_i, list):
+            new_value[i] = _list_manip(v_i)
+        elif _classlike(v_i):
+            new_value[i] = dict_to_model(v_i)
+        # otherwise ignore
+    return new_value
+
+
+def dict_to_model(dct: Dict[str, Any]) -> BaseModel:
+    """Convert dictionary to model."""
+    # Checks... # redundant? see _classlike()
+    if not isinstance(dct, dict):
+        raise TypeError("Only dicts are supported right now.")
+    if KLS_MARK_STR not in dct.keys():
+        raise ValueError("Model is not a supported type.")
+    pyd_kls = import_string(dct[KLS_MARK_STR])
+    assert issubclass(pyd_kls, BaseModel)
+
+    raw = dict(dct)
+    for key, value in dct.items():
+        if _classlike(value):
+            raw[key] = dict_to_model(value)
+        elif isinstance(value, list):
+            raw[key] = _list_manip(value)
+        # otherwise ignore
+    # return pyd_kls(**raw)
+    return parse_obj_as(pyd_kls, raw)
+
+
+def model_to_dict(model: BaseModel) -> Dict[str, Any]:
+    """Conver model to dictionary."""
+    with PatchPydanticIter():
+        return model.dict()

--- a/src/pydantic_kedro/_dict_io.py
+++ b/src/pydantic_kedro/_dict_io.py
@@ -2,10 +2,11 @@
 
 from contextlib import AbstractContextManager
 from types import TracebackType
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, List, Optional, Type, Union
 
 from pydantic import BaseModel
-from pydantic.utils import import_string
+
+from ._internals import import_string
 
 KLS_MARK_STR = "class"
 
@@ -126,8 +127,11 @@ def _dict_manip(value: Dict[str, Any]) -> Dict[str, Any]:
     return new_value
 
 
-def dict_to_model(dct: Dict[str, Any]) -> BaseModel:
-    """Convert dictionary to model."""
+def dict_to_model(dct: Union[Dict[str, Any], List[Any]]) -> BaseModel:
+    """Convert dictionary (or, optionally, list) to model."""
+    if isinstance(dct, list):
+        dct = {"__root__": dct}
+
     # Checks... # redundant? see _classlike()
     if not isinstance(dct, dict):
         raise TypeError("Only dicts are supported right now.")

--- a/src/pydantic_kedro/_dict_io.py
+++ b/src/pydantic_kedro/_dict_io.py
@@ -91,7 +91,7 @@ class PatchPydanticIter(AbstractContextManager):
         __exc_value: Optional[BaseException] = None,
         __traceback: Optional[TracebackType] = None,
     ) -> Optional[bool]:
-        BaseModel._iter = self.orig_iter
+        BaseModel._iter = self.orig_iter  # type: ignore
         return super().__exit__(__exc_type, __exc_value, __traceback)
 
 

--- a/src/pydantic_kedro/_internals.py
+++ b/src/pydantic_kedro/_internals.py
@@ -128,7 +128,7 @@ def create_expanded_model(model: BaseModel) -> BaseModel:
 
     field_defs = {KLS_MARK_STR: (str, pyd_kls_path)}
 
-    tmp_kls = create_model(
+    tmp_kls = create_model(  # type: ignore
         pyd_kls.__name__,
         __base__=pyd_kls,
         __module__=pyd_kls.__module__,

--- a/src/pydantic_kedro/_internals.py
+++ b/src/pydantic_kedro/_internals.py
@@ -88,11 +88,14 @@ def create_expanded_model(model: BaseModel) -> BaseModel:
     if KLS_MARK_STR in pyd_kls.__fields__.keys():
         raise ValueError(f"Marker {KLS_MARK_STR!r} already exists as a field; can't dump model.")
     pyd_kls_path = f"{pyd_kls.__module__}.{pyd_kls.__qualname__}"
+
+    field_defs = {KLS_MARK_STR: (str, pyd_kls_path)}
+
     tmp_kls = create_model(
         pyd_kls.__name__,
         __base__=pyd_kls,
         __module__=pyd_kls.__module__,
-        **{KLS_MARK_STR: (str, pyd_kls_path)},
+        **field_defs,
     )
     tmp_obj = tmp_kls(**dict(model._iter(to_dict=False)))
     return tmp_obj

--- a/src/pydantic_kedro/datasets/folder.py
+++ b/src/pydantic_kedro/datasets/folder.py
@@ -94,7 +94,7 @@ class KedroDataSetSpec(BaseModel):
         for k, v in params_raw.items():
             if k in sig.parameters:
                 params[k] = v
-        return kls(**params)
+        return kls(**params)  # type: ignore
 
 
 KedroDataSetSpec.update_forward_refs()

--- a/src/pydantic_kedro/datasets/folder.py
+++ b/src/pydantic_kedro/datasets/folder.py
@@ -25,6 +25,7 @@ __all__ = ["PydanticFolderDataSet"]
 DATA_PLACEHOLDER = "__DATA_PLACEHOLDER__"
 
 JsonPath = str  # not a "real" JSON Path, but just `.`-separated
+ImportStr = str
 
 logger = logging.getLogger(__name__)
 
@@ -111,14 +112,17 @@ class FolderFormatMetadata(BaseModel):
         Model parameters, encoded with a data path.
     catalog : dict
         Mapping of "json path" to a dataset spec.
+    pydantic_types : dict
+        Mapping of "json path" to the Pydantic model type, for nested models.
     """
 
     model_class: str
     model_info: Union[Dict[str, Any], List[Any]]
     catalog: Dict[JsonPath, KedroDataSetSpec] = {}
+    # pydantic_types: Dict[JsonPath, ImportStr] = {}
 
 
-def mutate_jsp(struct: Union[Dict[str, Any], List[Any]], jsp: List[str], obj: Any) -> None:
+def mutate_jsp(struct: Union[Dict[str, Any], List[Any]], jsp: List[JsonPath], obj: Any) -> None:
     """Mutates `struct` in-place given the jsp (which is json-path-like)."""
     if isinstance(struct, dict):
         key = jsp[0]

--- a/src/pydantic_kedro/datasets/json.py
+++ b/src/pydantic_kedro/datasets/json.py
@@ -85,7 +85,7 @@ class PydanticJsonDataSet(AbstractDataSet[BaseModel, BaseModel]):
             __module__=pyd_kls.__module__,
             **{KLS_MARK_STR: (str, pyd_kls_path)},
         )
-        tmp_obj = tmp_kls(**data.dict())
+        tmp_obj = tmp_kls(**dict(data._iter(to_dict=False)))
 
         # Open file and write to it
         save_path = get_filepath_str(self._filepath, self._protocol)

--- a/src/pydantic_kedro/datasets/json.py
+++ b/src/pydantic_kedro/datasets/json.py
@@ -7,10 +7,9 @@ from typing import Any, Dict, no_type_check
 import fsspec
 from fsspec import AbstractFileSystem
 from kedro.io.core import AbstractDataSet, get_filepath_str, get_protocol_and_path
-from pydantic import BaseModel, parse_obj_as
-from pydantic.utils import import_string
+from pydantic import BaseModel
 
-from pydantic_kedro._internals import KLS_MARK_STR, create_expanded_model
+from pydantic_kedro._dict_io import PatchPydanticIter, dict_to_model
 
 
 class PydanticJsonDataSet(AbstractDataSet[BaseModel, BaseModel]):
@@ -63,24 +62,17 @@ class PydanticJsonDataSet(AbstractDataSet[BaseModel, BaseModel]):
         with self._fs.open(load_path, mode="r") as f:
             dct = json.load(f)
         assert isinstance(dct, dict), "JSON root must be a mapping."
-        if KLS_MARK_STR not in dct.keys():
-            raise TypeError(f"Cannot determine pydantic model type, missing {KLS_MARK_STR!r}")
-        pyd_kls = import_string(dct[KLS_MARK_STR])
-        assert issubclass(pyd_kls, BaseModel), f"Type must be a Pydantic model, got {type(pyd_kls)!r}."
-        dct.pop(KLS_MARK_STR)  # don't accidentally pass to proper model
-        res = parse_obj_as(pyd_kls, dct)
+        res = dict_to_model(dct)
         return res  # type: ignore
 
     @no_type_check
     def _save(self, data: BaseModel) -> None:
         """Save Pydantic model to the filepath."""
-        # Add metadata to our Pydantic model
-        tmp_obj = create_expanded_model(data)
-
         # Open file and write to it
         save_path = get_filepath_str(self._filepath, self._protocol)
-        with self._fs.open(save_path, mode="w") as f:
-            f.write(tmp_obj.json())
+        with PatchPydanticIter():
+            with self._fs.open(save_path, mode="w") as f:
+                f.write(data.json())
 
     def _describe(self) -> Dict[str, Any]:
         """Return a dict that describes the attributes of the dataset."""

--- a/src/pydantic_kedro/datasets/yaml.py
+++ b/src/pydantic_kedro/datasets/yaml.py
@@ -6,11 +6,11 @@ from typing import Any, Dict, no_type_check
 import fsspec
 from fsspec import AbstractFileSystem
 from kedro.io.core import AbstractDataSet, get_filepath_str, get_protocol_and_path
-from pydantic import BaseModel, Field, create_model
+from pydantic import BaseModel, Field
 from pydantic.utils import import_string
 from pydantic_yaml import parse_yaml_file_as, to_yaml_file
 
-KLS_MARK_STR = "class"
+from pydantic_kedro._internals import KLS_MARK_STR, create_expanded_model
 
 
 class _YamlPreLoader(BaseModel):
@@ -79,17 +79,7 @@ class PydanticYamlDataSet(AbstractDataSet[BaseModel, BaseModel]):
     def _save(self, data: BaseModel) -> None:
         """Save Pydantic model to the filepath."""
         # Add metadata to our Pydantic model
-        pyd_kls = type(data)
-        if KLS_MARK_STR in pyd_kls.__fields__.keys():
-            raise ValueError(f"Marker {KLS_MARK_STR!r} already exists as a field; can't dump model.")
-        pyd_kls_path = f"{pyd_kls.__module__}.{pyd_kls.__qualname__}"
-        tmp_kls = create_model(
-            pyd_kls.__name__,
-            __base__=pyd_kls,
-            __module__=pyd_kls.__module__,
-            **{KLS_MARK_STR: (str, pyd_kls_path)},
-        )
-        tmp_obj = tmp_kls(**dict(data._iter(to_dict=False)))
+        tmp_obj = create_expanded_model(data)
 
         # Open file and write to it
         save_path = get_filepath_str(self._filepath, self._protocol)

--- a/src/pydantic_kedro/datasets/yaml.py
+++ b/src/pydantic_kedro/datasets/yaml.py
@@ -89,7 +89,7 @@ class PydanticYamlDataSet(AbstractDataSet[BaseModel, BaseModel]):
             __module__=pyd_kls.__module__,
             **{KLS_MARK_STR: (str, pyd_kls_path)},
         )
-        tmp_obj = tmp_kls(**data.dict())
+        tmp_obj = tmp_kls(**dict(data._iter(to_dict=False)))
 
         # Open file and write to it
         save_path = get_filepath_str(self._filepath, self._protocol)

--- a/src/test/test_nested_subtypes.py
+++ b/src/test/test_nested_subtypes.py
@@ -59,6 +59,6 @@ def test_nested_subclass(
     # Nested round-trip (should also always work, but is more diffictult)
     nest = Bazzifier(maker=obj)
     save_model(nest, f"{tmpdir}/nest", format=format)
-    # nest2 = load_model(f"{tmpdir}/nest", Bazzifier)
-    # assert nest.maker == nest2.maker
-    # assert nest.maker.get_baz() == nest2.maker.get_baz()
+    nest2 = load_model(f"{tmpdir}/nest", Bazzifier)
+    assert nest.maker == nest2.maker
+    assert nest.maker.get_baz() == nest2.maker.get_baz()

--- a/src/test/test_nested_subtypes.py
+++ b/src/test/test_nested_subtypes.py
@@ -79,5 +79,5 @@ def test_deeper_nested_subclass(format: Literal["auto", "zip", "folder", "yaml",
     nest = MultiBazzifier(maker_list=[a, c], maker_dict={"a": a, "c": c})
     # Nested round-trip (should also always work, but is much more diffictult)
     save_model(nest, f"{tmpdir}/nest", format=format)
-    nest2 = load_model(f"{tmpdir}/nest", Bazzifier)
+    nest2 = load_model(f"{tmpdir}/nest", MultiBazzifier)
     assert nest == nest2

--- a/src/test/test_nested_subtypes.py
+++ b/src/test/test_nested_subtypes.py
@@ -1,0 +1,64 @@
+"""Tests for values which are subclasses of the Pydantic field types."""
+
+from abc import abstractmethod
+from typing import Literal
+
+import pytest
+from pydantic import BaseModel
+
+from pydantic_kedro import load_model, save_model
+
+
+class AbstractBaz(BaseModel):
+    """Abstract base model which is used as an interface.
+
+    This can occur with ANY model type, however with abstract models it's much more apparent.
+    You can't instantiate models with
+    """
+
+    foo: str
+
+    @abstractmethod
+    def get_baz(self) -> str:
+        """Return baz value."""
+
+
+class AlwaysBaz(AbstractBaz):
+    """Model that returns baz as "baz"."""
+
+    def get_baz(self) -> str:
+        """Return baz as "baz"."""
+        return "baz"
+
+
+class CopyBaz(AbstractBaz):
+    """Model that copies foo into baz."""
+
+    def get_baz(self) -> str:
+        """Return baz as a copy of foo."""
+        return self.foo
+
+
+class Bazzifier(BaseModel):
+    """Higher-level model with nested 'bazzifier' value."""
+
+    maker: AbstractBaz
+
+
+@pytest.mark.parametrize("format", ["auto", "zip", "folder", "yaml", "json"])
+@pytest.mark.parametrize("obj", [AlwaysBaz(foo="always"), CopyBaz(foo="copy")])
+def test_nested_subclass(
+    obj: AbstractBaz, format: Literal["auto", "zip", "folder", "yaml", "json"], tmpdir: str
+):
+    """Test round-trip of objects with a nested subclass."""
+    # Initial round-trip (should always work)
+    save_model(obj, f"{tmpdir}/obj", format=format)
+    obj2 = load_model(f"{tmpdir}/obj", AbstractBaz)
+    assert obj.foo == obj2.foo
+    assert obj.get_baz() == obj2.get_baz()
+    # Nested round-trip (should also always work, but is more diffictult)
+    nest = Bazzifier(maker=obj)
+    save_model(nest, f"{tmpdir}/nest", format=format)
+    # nest2 = load_model(f"{tmpdir}/nest", Bazzifier)
+    # assert nest.maker == nest2.maker
+    # assert nest.maker.get_baz() == nest2.maker.get_baz()


### PR DESCRIPTION
Fixes #31 once complete.

Currently only a partial fix...

It looks like we need to store more metadata with the models, i.e. what field type is EVERY field.
This is even a problem for JSON or YAML models.
That means a lot of modification to the model structure... oof.