### PR TITLE
Fix: Strict Classes Support

### DIFF
--- a/src/pydantic_kedro/_dict_io.py
+++ b/src/pydantic_kedro/_dict_io.py
@@ -149,7 +149,9 @@ def dict_to_model(dct: Union[Dict[str, Any], List[Any]]) -> BaseModel:
         elif isinstance(value, dict):
             raw[key] = _dict_manip(value)
         # otherwise ignore
-    return pyd_kls(**raw)  # Consider parse_obj_as(pyd_kls, raw) ?
+    keywords = dict(raw)
+    del keywords[KLS_MARK_STR]
+    return pyd_kls(**keywords)  # Consider parse_obj_as(pyd_kls, keywords) ?
 
 
 def model_to_dict(model: BaseModel) -> Dict[str, Any]:

--- a/src/test/test_settings.py
+++ b/src/test/test_settings.py
@@ -1,0 +1,29 @@
+"""Test issue with settings."""
+
+import pytest
+from pydantic import BaseModel, BaseSettings
+from typing_extensions import Literal
+
+from pydantic_kedro import load_model, save_model
+
+
+class ExSettings(BaseSettings):
+    """Settings class."""
+
+    val: str
+
+
+class ExModel(BaseModel):
+    """Model class."""
+
+    x: int = 1
+    settings: ExSettings
+
+
+@pytest.mark.parametrize("format", ["auto", "zip", "folder", "yaml", "json"])
+def test_rt_settings(tmpdir: str, format: Literal["auto", "zip", "folder", "yaml", "json"]):
+    """Test settings round-trip."""
+    obj = ExModel(settings=ExSettings(val="val"))
+    save_model(obj, f"{tmpdir}/obj", format=format)
+    obj2 = load_model(f"{tmpdir}/obj", ExModel)
+    assert obj.settings == obj2.settings

--- a/src/test/test_strict.py
+++ b/src/test/test_strict.py
@@ -1,4 +1,4 @@
-"""Test issue with settings."""
+"""Test strict models and BaseSettings subclasses."""
 
 import pytest
 from pydantic import BaseModel, BaseSettings
@@ -20,6 +20,17 @@ class ExModel(BaseModel):
     settings: ExSettings
 
 
+class StrictModel(BaseModel):
+    """Strict no-extras values."""
+
+    val: str
+
+    class Config:
+        """Pydantic model configuration."""
+
+        extra = "forbid"
+
+
 @pytest.mark.parametrize("format", ["auto", "zip", "folder", "yaml", "json"])
 def test_rt_settings(tmpdir: str, format: Literal["auto", "zip", "folder", "yaml", "json"]):
     """Test settings round-trip."""
@@ -27,3 +38,12 @@ def test_rt_settings(tmpdir: str, format: Literal["auto", "zip", "folder", "yaml
     save_model(obj, f"{tmpdir}/obj", format=format)
     obj2 = load_model(f"{tmpdir}/obj", ExModel)
     assert obj.settings == obj2.settings
+
+
+@pytest.mark.parametrize("format", ["auto", "zip", "folder", "yaml", "json"])
+def test_rt_strict_model(tmpdir: str, format: Literal["auto", "zip", "folder", "yaml", "json"]):
+    """Test strict_model round-trip."""
+    obj = StrictModel(val="val")
+    save_model(obj, f"{tmpdir}/obj", format=format)
+    obj2 = load_model(f"{tmpdir}/obj", StrictModel)
+    assert obj.val == obj2.val


### PR DESCRIPTION
Fixes issue where classes with `extra = "forbid"` configuration, such as `BaseSettings`, were fed the `class:` argument upon creation.

Also adds test cases for regressions.