### PR TITLE
Fix: Auto-create parent directories when saving locally

### DIFF
--- a/src/pydantic_kedro/datasets/folder.py
+++ b/src/pydantic_kedro/datasets/folder.py
@@ -321,6 +321,9 @@ class PydanticFolderDataSet(AbstractDataSet[BaseModel, BaseModel]):
                 return {k: visit3(v, f"{jsp}.{k}", base_path) for k, v in obj.items()}
             return obj
 
+        # Ensure directory exists
+        Path(filepath).mkdir(parents=True, exist_ok=True)
+
         model_info = visit3(rt, "", base_path=filepath)
         if not isinstance(model_info, dict):
             raise NotImplementedError("Only dict root is supported for now.")

--- a/src/pydantic_kedro/datasets/json.py
+++ b/src/pydantic_kedro/datasets/json.py
@@ -1,6 +1,7 @@
 """JSON dataset definition for Pydantic."""
 
 import json
+import warnings
 from pathlib import PurePosixPath
 from typing import Any, Dict, no_type_check
 
@@ -70,6 +71,15 @@ class PydanticJsonDataSet(AbstractDataSet[BaseModel, BaseModel]):
         """Save Pydantic model to the filepath."""
         # Open file and write to it
         save_path = get_filepath_str(self._filepath, self._protocol)
+
+        # Ensure parent directory exists
+        try:
+            if "/" in save_path:
+                parent_path, *_ = save_path.rsplit("/", maxsplit=1)
+                self._fs.makedirs(parent_path, exist_ok=True)
+        except Exception:
+            warnings.warn(f"Failed to create parent path for {save_path}")
+
         with PatchPydanticIter():
             with self._fs.open(save_path, mode="w") as f:
                 f.write(data.json())

--- a/src/pydantic_kedro/datasets/yaml.py
+++ b/src/pydantic_kedro/datasets/yaml.py
@@ -1,5 +1,6 @@
 """YAML dataset definition for Pydantic."""
 
+import warnings
 from pathlib import PurePosixPath
 from typing import Any, Dict, no_type_check
 
@@ -73,6 +74,15 @@ class PydanticYamlDataSet(AbstractDataSet[BaseModel, BaseModel]):
         """Save Pydantic model to the filepath."""
         # Open file and write to it
         save_path = get_filepath_str(self._filepath, self._protocol)
+
+        # Ensure parent directory exists
+        try:
+            if "/" in save_path:
+                parent_path, *_ = save_path.rsplit("/", maxsplit=1)
+                self._fs.makedirs(parent_path, exist_ok=True)
+        except Exception:
+            warnings.warn(f"Failed to create parent path for {save_path}")
+
         with PatchPydanticIter():
             with self._fs.open(save_path, mode="w") as f:
                 to_yaml_file(f, data)

--- a/src/test/test_ds_simple.py
+++ b/src/test/test_ds_simple.py
@@ -40,7 +40,12 @@ types = [
 @pytest.mark.parametrize("kls", types)
 def test_simple_model_rt(mdl: SimpleTestModel, kls: AbstractDataSet, tmpdir):  # type: ignore
     """Tests whether a simple model survives roundtripping."""
-    paths = [f"{tmpdir}/model_on_disk", f"memory://{tmpdir}/model_in_memory"]
+    paths = [
+        f"{tmpdir}/model_on_disk",
+        f"{tmpdir}/new_folder/model_on_disk",
+        f"memory://{tmpdir}/model_in_memory",
+        f"memory://{tmpdir}/new_folder/model_in_memory",
+    ]
     for path in paths:
         ds: AbstractDataSet = kls(path)  # type: ignore
         ds.save(mdl)


### PR DESCRIPTION
Add auto-creation of parent directories, where possible. Fallback in case they can't be added.

Updated tests to include subpaths in non-existent directories.