### PR TITLE
Support installations of Pydantic v2 (but only v1 backported models)

### DIFF
--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -20,6 +20,7 @@ jobs:
           - "3.10"
         lib-pydantic:
           - "1.10.0"
+          - "2.6.4"
         deps:
           - dev,docs
     steps:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This example works for "pure", JSON-safe Pydantic models via
 `PydanticJsonDataset`:
 
 ```python
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from pydantic_kedro import PydanticJsonDataset
 
 
@@ -61,7 +61,7 @@ Pydantic models:
 ```python
 from tempfile import TemporaryDirectory
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from pydantic_kedro import load_model, save_model
 
 class MyModel(BaseModel):

--- a/docs/arbitrary_types.md
+++ b/docs/arbitrary_types.md
@@ -10,7 +10,7 @@ You can't save/load these via JSON, but you can use the other dataset types:
 
 ```python
 from tempfile import TemporaryDirectory
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from pydantic_kedro import PydanticZipDataset
 
 
@@ -91,7 +91,7 @@ Here's a example for [pandas](https://pandas.pydata.org/) and Pydantic V1:
 ```python
 import pandas as pd
 from kedro_datasets.pandas import ParquetDataset
-from pydantic import validator
+from pydantic.v1 import validator
 from pydantic_kedro import ArbModel, PydanticZipDataset
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ my_pydantic_model:
 Then use it as usual within your Kedro pipelines:
 
 ```python
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from kedro.pipeline import node
 
 class SomeModel(BaseModel):
@@ -84,7 +84,7 @@ or [PydanticYamlDataset][pydantic_kedro.PydanticYamlDataset]
 to save your model to any `fsspec`-supported location:
 
 ```python
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from pydantic_kedro import PydanticJsonDataset
 
 

--- a/docs/standalone_usage.md
+++ b/docs/standalone_usage.md
@@ -7,7 +7,7 @@ You can use `pydantic-kedro` to save and load your Pydantic models without invok
 ```python
 from tempfile import TemporaryDirectory
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from pydantic_kedro import load_model, save_model
 
 class MyModel(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "pydantic>=1.10.0,<2",   # TODO
+    "pydantic>=1.10.0,<3",   # WIP
     "pydantic-yaml>=1.1.2",
     "ruamel-yaml<0.18",      # Current limitation
     "kedro>=0.19.3,<0.20",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 dependencies = [
     "pydantic>=1.10.0,<3",   # WIP
-    "pydantic-yaml>=1.1.2",
+    "pydantic-yaml>=1.3.0",
     "ruamel-yaml<0.18",      # Current limitation
     "kedro>=0.19.3,<0.20",
     "kedro-datasets>=2.1.0",

--- a/src/pydantic_kedro/_dict_io.py
+++ b/src/pydantic_kedro/_dict_io.py
@@ -4,7 +4,7 @@ from contextlib import AbstractContextManager
 from types import TracebackType
 from typing import Any, Dict, List, Optional, Type, Union
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from ._internals import import_string
 

--- a/src/pydantic_kedro/_internals.py
+++ b/src/pydantic_kedro/_internals.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Dict, Type
 
 from kedro_datasets.pickle.pickle_dataset import PickleDataset
 from kedro.io.core import AbstractDataset
-from pydantic import BaseModel, create_model
+from pydantic.v1 import BaseModel, create_model
 
 KLS_MARK_STR = "class"
 

--- a/src/pydantic_kedro/datasets/auto.py
+++ b/src/pydantic_kedro/datasets/auto.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Literal, Union
 import fsspec
 from fsspec import AbstractFileSystem
 from kedro.io.core import AbstractDataset, get_protocol_and_path
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from .folder import PydanticFolderDataset
 from .json import PydanticJsonDataset

--- a/src/pydantic_kedro/datasets/folder.py
+++ b/src/pydantic_kedro/datasets/folder.py
@@ -14,7 +14,7 @@ from fsspec import AbstractFileSystem
 from fsspec.core import strip_protocol
 from fsspec.implementations.local import LocalFileSystem
 from kedro.io.core import AbstractDataset, parse_dataset_definition
-from pydantic import BaseConfig, BaseModel, Extra, Field
+from pydantic.v1 import BaseConfig, BaseModel, Extra, Field
 
 from pydantic_kedro._dict_io import PatchPydanticIter, dict_to_model
 from pydantic_kedro._internals import get_kedro_default, get_kedro_map, import_string

--- a/src/pydantic_kedro/datasets/json.py
+++ b/src/pydantic_kedro/datasets/json.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, no_type_check
 import fsspec
 from fsspec import AbstractFileSystem
 from kedro.io.core import AbstractDataset, get_filepath_str, get_protocol_and_path
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from pydantic_kedro._dict_io import PatchPydanticIter, dict_to_model
 

--- a/src/pydantic_kedro/datasets/yaml.py
+++ b/src/pydantic_kedro/datasets/yaml.py
@@ -8,7 +8,7 @@ import fsspec
 import ruamel.yaml as yaml
 from fsspec import AbstractFileSystem
 from kedro.io.core import AbstractDataset, get_filepath_str, get_protocol_and_path
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from pydantic_yaml import to_yaml_file
 
 from pydantic_kedro._dict_io import PatchPydanticIter, dict_to_model

--- a/src/pydantic_kedro/datasets/zip.py
+++ b/src/pydantic_kedro/datasets/zip.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 import fsspec
 from fsspec.implementations.zip import ZipFileSystem
 from kedro.io.core import AbstractDataset
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from pydantic_kedro._local_caching import get_cache_dir
 

--- a/src/pydantic_kedro/models.py
+++ b/src/pydantic_kedro/models.py
@@ -4,7 +4,7 @@ from typing import Callable, Dict, Type
 
 from kedro_datasets.pickle.pickle_dataset import PickleDataset
 from kedro.io import AbstractDataset
-from pydantic import BaseConfig, BaseModel
+from pydantic.v1 import BaseConfig, BaseModel
 
 
 def _kedro_default(x: str) -> PickleDataset:

--- a/src/pydantic_kedro/utils.py
+++ b/src/pydantic_kedro/utils.py
@@ -3,7 +3,7 @@
 from typing import Literal, Type, TypeVar
 
 from kedro.io.core import AbstractDataset
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from pydantic_kedro.datasets.auto import PydanticAutoDataset
 from pydantic_kedro.datasets.folder import PydanticFolderDataset

--- a/src/test/catalogs/test_basic_catalog.py
+++ b/src/test/catalogs/test_basic_catalog.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from kedro.config import OmegaConfigLoader
 from kedro.io import DataCatalog
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from pydantic_kedro import PydanticJsonDataset
 

--- a/src/test/test_auto.py
+++ b/src/test/test_auto.py
@@ -1,6 +1,6 @@
 """Specialized tests for `PydanticAutoDataset`."""
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from pydantic_kedro import PydanticAutoDataset, PydanticJsonDataset, PydanticZipDataset
 

--- a/src/test/test_ds_simple.py
+++ b/src/test/test_ds_simple.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import pytest
 from kedro.io.core import AbstractDataset
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from pydantic_kedro import (
     PydanticAutoDataset,

--- a/src/test/test_inheritance.py
+++ b/src/test/test_inheritance.py
@@ -8,7 +8,7 @@ import pytest
 from kedro_datasets.pandas.csv_dataset import CSVDataset
 from kedro_datasets.pandas.parquet_dataset import ParquetDataset
 from kedro_datasets.pickle.pickle_dataset import PickleDataset
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from pydantic_kedro import PydanticFolderDataset
 

--- a/src/test/test_nested_subtypes.py
+++ b/src/test/test_nested_subtypes.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 from typing import Dict, List, Literal
 
 import pytest
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from pydantic_kedro import load_model, save_model
 

--- a/src/test/test_strict.py
+++ b/src/test/test_strict.py
@@ -1,7 +1,7 @@
 """Test strict models and BaseSettings subclasses."""
 
 import pytest
-from pydantic import BaseModel, BaseSettings
+from pydantic.v1 import BaseModel, BaseSettings
 from typing_extensions import Literal
 
 from pydantic_kedro import load_model, save_model

--- a/src/test/test_utils.py
+++ b/src/test/test_utils.py
@@ -1,6 +1,6 @@
 """Test utility functions, loading and saving models."""
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from pydantic_kedro import load_model, save_model
 


### PR DESCRIPTION
Pydantic v2 updated a lot, but for the sake of migration they have a backport of the Pydantic v1 features within the `pydantic.v1.*` namespace.

Since `pydantic-kedro` does a bit of a hacky thing with serialization in order to save datasets... that doesn't work in a "full" Pydantic v2, and a big rewrite is needed to actually support the v2 syntax. But we can support the v1 backport.

Which is what this does now.